### PR TITLE
add documentation for setting network interfaces to be used with openmpi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,39 @@ All experiments are with ``mpi4py`` and will try to spawned workers depending on
 
 All figures can be generated using scripts in ``benchmarks``. Each script will generate and save the data to reproduce the figure. The figure can then be plotted by re-running the same script with the argument ``--plot``. The figures are saved in pdf in the ``benchmarks_results`` folder. The computation are cached with ``joblib`` to be robust to failures.
 
+.. note::
+
+   Open MPI tries to use all **up** network interfaces. This might cause the program to hang due to virtual network interfaces which could not actually be used to communicate with MPI processes. For more info `Open MPI FAQ <https://www.open-mpi.org/faq/?category=tcp#tcp-selection>`_.
+
+   In this case run the ``mpirun`` command:
+
+   - either spefifying usable interfaces using ``--mca btl_tcp_if_include`` parameter:
+
+   .. code-block:: bash
+
+	 $ mpirun -np 1 \
+		  --mca btl_tcp_if_include wlp2s0 \
+		  --hostfile hostfile \
+		  python -m mpi4py examples/plot_mandrill.py
+
+   - or by excluding the virtual interfaces using ``--mca btl_tcp_if_exclude`` parameter:
+
+   .. code-block:: bash
+
+	 $ mpirun -np 1 \
+		  --mca btl_tcp_if_exclude docker0 \
+		  --hostfile hostfile \
+		  python -m mpi4py examples/plot_mandrill.py
+
+   - alternatively by setting environment variables ``OMPI_MCA_btl_tcp_if_include`` or ``OMPI_MCA_btl_tcp_if_exclude``
+
+   .. code-block:: bash
+
+	 $ export OMPI_MCA_btl_tcp_if_include="wlp2s0"
+
+	 $ export OMPI_MCA_btl_tcp_if_exclude="docker0"``
+
+
 .. |Build Status| image:: https://github.com/tomMoral/dicodile/workflows/unittests/badge.svg
 .. |codecov| image:: https://codecov.io/gh/tomMoral/dicodile/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/tomMoral/dicodile

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ All figures can be generated using scripts in ``benchmarks``. Each script will g
 
    Open MPI tries to use all **up** network interfaces. This might cause the program to hang due to virtual network interfaces which could not actually be used to communicate with MPI processes. For more info `Open MPI FAQ <https://www.open-mpi.org/faq/?category=tcp#tcp-selection>`_.
 
-   In this case run the ``mpirun`` command:
+   In case your program hangs, you can launch computation with the ``mpirun`` command:
 
    - either spefifying usable interfaces using ``--mca btl_tcp_if_include`` parameter:
 

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ All figures can be generated using scripts in ``benchmarks``. Each script will g
 		  --hostfile hostfile \
 		  python -m mpi4py examples/plot_mandrill.py
 
-   - alternatively by setting environment variables ``OMPI_MCA_btl_tcp_if_include`` or ``OMPI_MCA_btl_tcp_if_exclude``
+Alternatively, you can also restrict the used interface by setting environment variables ``OMPI_MCA_btl_tcp_if_include`` or ``OMPI_MCA_btl_tcp_if_exclude``
 
    .. code-block:: bash
 


### PR DESCRIPTION
Open MPI hangs if network interfaces are not set correctly. 

This happens when there are virtual network interfaces which could not actually be used to communicate with MPI processes, eg docker bridge networks.