### PR TITLE
set failfast to false

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,6 +11,7 @@ jobs:
       run:
         shell: bash -l {0}
     strategy:
+      fail-fast: false
       matrix:
         mpi_install: [system, conda]
         python: [3.8]


### PR DESCRIPTION
This is to prevent a failing job to cancel other jobs so that we can see which jobs fail/pass.