### PR TITLE
run pipeline on tags as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: main
+    tags:
+      - '*'
 
 jobs:
   # flake8 linting


### PR DESCRIPTION
Hopefully, this should now allow tag pushes to trigger the release pipeline.