### PR TITLE
Update github pages action to use a more recent sphinx image

### DIFF
--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Generate HTML docs
-        uses: ammaraskar/sphinx-action@master
+        uses: ax3l/sphinx-action@newer-sphinx
         env:
           ALLOW: --allow-run-as-root
         with:


### PR DESCRIPTION
Fixes #41 

https://github.com/ax3l/sphinx-action is a fork of https://github.com/ammaraskar/sphinx-action that fixes sphinx image version.