### PR TITLE
CLN remove deps on dask-jobqueue which is not used

### DIFF
--- a/dicodile_env.yml
+++ b/dicodile_env.yml
@@ -16,7 +16,5 @@ dependencies:
   - python-spams
   - mpi4py
   - pip:
-    - git+https://github.com/dask/dask-jobqueue.git
-    - threadpoolctl
     - -e .
 


### PR DESCRIPTION
Tentative to clean up the `environment.yml` file for dicodile from unused dependencies.

fixes #43 