### PR TITLE
ENH remove backend checks for mpi

### DIFF
--- a/dicodile/workers/dicod_worker.py
+++ b/dicodile/workers/dicod_worker.py
@@ -648,11 +648,19 @@ class DICODWorker:
         If main is True, this synchronization must also be called in the main
         program.
         """
-        self._synchronize_workers_mpi(with_main=with_main)
+        if with_main:
+            comm = MPI.Comm.Get_parent()
+        else:
+            comm = MPI.COMM_WORLD
+        comm.Barrier()
 
     def recv_params(self):
         """Receive the parameter of the algorithm from the master node."""
-        self.rank, self.n_workers, params = self._recv_params_mpi()
+        comm = MPI.Comm.Get_parent()
+
+        self.rank = comm.Get_rank()
+        self.n_workers = comm.Get_size()
+        params = comm.bcast(None, root=0)
 
         self.tol = params['tol']
         self.reg = params['reg']
@@ -788,67 +796,24 @@ class DICODWorker:
 
     def recv_array(self, shape):
         """Receive the part of the signal to encode from the master node."""
-        return self._recv_array_mpi(shape=shape)
+        comm = MPI.Comm.Get_parent()
+        rank = comm.Get_rank()
+
+        arr = np.empty(shape, dtype='d')
+        comm.Recv([arr.ravel(), MPI.DOUBLE], source=0,
+                  tag=constants.TAG_ROOT + rank)
+        return arr
 
     def send_message(self, msg, tag, i_worker, wait=False):
         """Send a message to a specified worker."""
         assert self.rank != i_worker
-        return self._send_message_mpi(msg, tag, i_worker, wait=wait)
 
-    def send_result(self):
-        self._send_result_mpi()
-
-    def return_array(self, sig):
-        self._return_array_mpi(sig)
-
-    def reduce_sum_array(self, arr):
-        self._reduce_sum_array_mpi(arr)
-
-    def gather_array(self, arr):
-        self._gather_array_mpi(arr)
-
-    def shutdown(self):
-        from ..utils.mpi import shutdown_mpi
-        shutdown_mpi()
-
-    ###########################################################################
-    #     mpi4py implementation
-    ###########################################################################
-
-    def _synchronize_workers_mpi(self, with_main=True):
-        if with_main:
-            comm = MPI.Comm.Get_parent()
-        else:
-            comm = MPI.COMM_WORLD
-        comm.Barrier()
-
-    def check_no_transitting_message(self, check_incoming=True):
-        """Check no message is in waiting to complete to or from this worker"""
-        if check_incoming and MPI.COMM_WORLD.Iprobe():
-            return False
-        while self.messages:
-            if not self.messages[0].Test() or (
-                    check_incoming and MPI.COMM_WORLD.Iprobe()):
-                return False
-            self.messages.pop(0)
-        assert len(self.messages) == 0, len(self.messages)
-        return True
-
-    def _recv_params_mpi(self):
-        comm = MPI.Comm.Get_parent()
-
-        rank = comm.Get_rank()
-        n_workers = comm.Get_size()
-        params = comm.bcast(None, root=0)
-        return rank, n_workers, params
-
-    def _send_message_mpi(self, msg, tag, i_worker, wait=False):
         if wait:
             return MPI.COMM_WORLD.Ssend([msg, MPI.DOUBLE], i_worker, tag=tag)
         else:
             return MPI.COMM_WORLD.Issend([msg, MPI.DOUBLE], i_worker, tag=tag)
 
-    def _send_result_mpi(self):
+    def send_result(self):
         comm = MPI.Comm.Get_parent()
         self.info("Reducing the distributed results", global_msg=True)
 
@@ -864,29 +829,36 @@ class DICODWorker:
 
         comm.Barrier()
 
-    def _recv_array_mpi(self, shape):
+    def return_array(self, sig):
         comm = MPI.Comm.Get_parent()
-        rank = comm.Get_rank()
-
-        arr = np.empty(shape, dtype='d')
-        comm.Recv([arr.ravel(), MPI.DOUBLE], source=0,
-                  tag=constants.TAG_ROOT + rank)
-        return arr
-
-    def _return_array_mpi(self, arr):
-        comm = MPI.Comm.Get_parent()
-        arr.astype('d')
-        comm.Send([arr, MPI.DOUBLE], dest=0,
+        sig.astype('d')
+        comm.Send([sig, MPI.DOUBLE], dest=0,
                   tag=constants.TAG_ROOT + self.rank)
 
-    def _reduce_sum_array_mpi(self, arr):
+    def reduce_sum_array(self, arr):
         comm = MPI.Comm.Get_parent()
         arr = np.array(arr, dtype='d')
         comm.Reduce([arr, MPI.DOUBLE], None, op=MPI.SUM, root=0)
 
-    def _gather_array_mpi(self, arr):
+    def gather_array(self, arr):
         comm = MPI.Comm.Get_parent()
         comm.gather(arr, root=0)
+
+    def check_no_transitting_message(self, check_incoming=True):
+        """Check no message is in waiting to complete to or from this worker"""
+        if check_incoming and MPI.COMM_WORLD.Iprobe():
+            return False
+        while self.messages:
+            if not self.messages[0].Test() or (
+                    check_incoming and MPI.COMM_WORLD.Iprobe()):
+                return False
+            self.messages.pop(0)
+        assert len(self.messages) == 0, len(self.messages)
+        return True
+
+    def shutdown(self):
+        from ..utils.mpi import shutdown_mpi
+        shutdown_mpi()
 
 
 if __name__ == "__main__":

--- a/dicodile/workers/dicod_worker.py
+++ b/dicodile/workers/dicod_worker.py
@@ -30,7 +30,7 @@ class DICODWorker:
     """Worker for DICOD, running LGCD locally and using MPI for communications
     """
 
-    def __init__(self, backend):
+    def __init__(self):
         self.D = None
 
     def run(self):

--- a/dicodile/workers/dicodile_worker.py
+++ b/dicodile/workers/dicodile_worker.py
@@ -4,7 +4,7 @@ from dicodile.utils.mpi import wait_message
 
 
 def dicodile_worker():
-    dicod_worker = DICODWorker(backend='mpi')
+    dicod_worker = DICODWorker()
 
     tag = wait_message()
     while tag != constants.TAG_DICODILE_STOP:

--- a/dicodile/workers/main_worker.py
+++ b/dicodile/workers/main_worker.py
@@ -18,7 +18,7 @@ def main():
     tag = wait_message()
     while tag != constants.TAG_WORKER_STOP:
         if tag == constants.TAG_WORKER_RUN_DICOD:
-            dicod = DICODWorker(backend='mpi')
+            dicod = DICODWorker()
             dicod.run()
         if tag == constants.TAG_WORKER_RUN_DICODILE:
             dicodile_worker()


### PR DESCRIPTION
Simplifies code removing all `backend  == "mpi"`checks.

MPI backend is not clearly separated. If another backend is to be implemented in the future, it would be better to implement in separate classes to a common Interface instead of if checks.

